### PR TITLE
Add Event support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mraerino/atem-go
+module github.com/everycastlabs/atem-go
 
 go 1.13
 


### PR DESCRIPTION
closes #3 

This PR is a draft right now... I wanted to see what you thought of the idea.

This way you can pass a map of callbacks into `SetEvents` - so far I only added support for `onTallyBySource` and `onTallyByIndex`... but it means you don't need to have a loop asking for the data... you get told when it's changed... 

